### PR TITLE
Use String(describing:) instead of String interpolation

### DIFF
--- a/Shared/Views/MatchedNoteView.swift
+++ b/Shared/Views/MatchedNoteView.swift
@@ -15,7 +15,7 @@ struct MatchedNoteView: View {
                     Spacer()
                         .frame(height: 24) // TODO: Fix this with alignment guides
                 }
-                Text("\(match.octave)")
+                Text(String(describing: match.octave))
                     // TODO: Avoid hardcoding size
                     .font(.system(size: 40, design: .rounded))
                     .foregroundColor(.secondary)


### PR DESCRIPTION
To make it clear that we don't want to localize this value