### PR TITLE
Set minimum tap width of transposition menu to 100 points

### DIFF
--- a/Shared/Views/TranspositionMenu.swift
+++ b/Shared/Views/TranspositionMenu.swift
@@ -20,6 +20,9 @@ struct TranspositionMenu: View {
             },
             label: {
                 Text(transpositions[selectedTransposition])
+                    // Increase tap area, some of the transpositions are just a single
+                    // letter so the tap area can otherwise be quite small.
+                    .frame(minWidth: 100, alignment: .leading)
             }
         )
         .transaction { transaction in


### PR DESCRIPTION
Some of the transpositions are just a single letter so the tap area can otherwise be quite small.