### PR TITLE
Fix ScaleNote.closestNote logic & add tests

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -90,3 +90,6 @@ identifier_name:
 file_name:
   excluded:
     - Alignment.swift
+
+large_tuple:
+  warning: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fix bug in tuning algorithm that would fail to accurately recognize a
+  sharp B or a flat C.
 * Fixed visual glitches when changing notes.
 
 ## 0.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
-* Fix bug in tuning algorithm that would fail to accurately recognize a
-  sharp B or a flat C.
+* Fixed a bug in tuning algorithm that would fail to accurately
+  recognize a sharp B or a flat C.
 * Fixed visual glitches when changing notes.
 
 ## 0.1.9

--- a/Shared/Models/Frequency.swift
+++ b/Shared/Models/Frequency.swift
@@ -4,7 +4,8 @@ import SwiftUI
 // MARK: - Type Definition
 
 struct Frequency: Equatable {
-    private var measurement: Measurement<UnitFrequency>
+    /// The underlying frequency `Measurement`.
+    private(set) var measurement: Measurement<UnitFrequency>
 
     /// The distance between frequencies in cents: https://en.wikipedia.org/wiki/Cent_%28music%29
     struct MusicalDistance: Hashable, ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral {
@@ -13,7 +14,13 @@ struct Frequency: Equatable {
 
         /// Humans can distinguish a difference in pitch of about 5–6 cents:
         /// https://en.wikipedia.org/wiki/Cent_%28music%29#Human_perception
-        var isPerceptible: Bool { fabsf(cents) > 5 }
+        var isPerceptible: Bool { fabsf(cents) > 6 }
+
+        /// A distance is flat if it is less than zero.
+        var isFlat: Bool { cents < 0 }
+
+        /// A distance is sharp if it is greater than zero.
+        var isSharp: Bool { cents > 0 }
 
         /// Color used to represent this distance.
         var color: Color { isPerceptible ? .red : .green }
@@ -122,5 +129,16 @@ extension Frequency {
     /// - returns: Distance in octaves to specified frequency.
     func distanceInOctaves(to frequency: Frequency) -> Int {
         return Int(distance(to: frequency).cents / MusicalDistance.octave.cents)
+    }
+
+    /// Creates a new frequency that's offset by the musical distance specified.
+    ///
+    /// - parameter distance: The musical distance to offset this frequency.
+    ///
+    /// - returns: A new frequency that's offset by the musical distance specified.
+    func adding(_ distance: MusicalDistance) -> Frequency {
+        var newMeasurement = measurement
+        newMeasurement.value = newMeasurement.value * Double(exp2(distance.cents / MusicalDistance.octave.cents))
+        return Frequency(measurement: newMeasurement)
     }
 }

--- a/ZenTuner.xcodeproj/project.pbxproj
+++ b/ZenTuner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		8F13E1B625ED345700C3F23D /* ColorAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F13E1B525ED345700C3F23D /* ColorAnimation.swift */; };
 		8F13E1B725ED345700C3F23D /* ColorAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F13E1B525ED345700C3F23D /* ColorAnimation.swift */; };
+		8F13E1C225ED533800C3F23D /* ClosestNoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F13E1C125ED533800C3F23D /* ClosestNoteTests.swift */; };
 		8F693E3925B87DB20054DB16 /* TranspositionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F693E3825B87DB20054DB16 /* TranspositionMenu.swift */; };
 		8F693E3A25B87DB20054DB16 /* TranspositionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F693E3825B87DB20054DB16 /* TranspositionMenu.swift */; };
 		8F8F67C525C093640024B4CB /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 8F8F67C425C093640024B4CB /* SnapshotTesting */; };
@@ -58,6 +59,7 @@
 
 /* Begin PBXFileReference section */
 		8F13E1B525ED345700C3F23D /* ColorAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorAnimation.swift; sourceTree = "<group>"; };
+		8F13E1C125ED533800C3F23D /* ClosestNoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClosestNoteTests.swift; sourceTree = "<group>"; };
 		8F693E3825B87DB20054DB16 /* TranspositionMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranspositionMenu.swift; sourceTree = "<group>"; };
 		8F8F67CC25C0938F0024B4CB /* TunerViewSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TunerViewSnapshotTests.swift; sourceTree = "<group>"; };
 		8FB571AA25B72146007C28BC /* ZenTunerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenTunerApp.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				8FE56CDC25BE05D20038664C /* TranspositionTests.swift */,
+				8F13E1C125ED533800C3F23D /* ClosestNoteTests.swift */,
 				8F8F67CC25C0938F0024B4CB /* TunerViewSnapshotTests.swift */,
 				8FE56CDE25BE05D20038664C /* Info.plist */,
 			);
@@ -401,6 +404,7 @@
 			files = (
 				8FE56CDD25BE05D20038664C /* TranspositionTests.swift in Sources */,
 				8F8F67CD25C0938F0024B4CB /* TunerViewSnapshotTests.swift in Sources */,
+				8F13E1C225ED533800C3F23D /* ClosestNoteTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ZenTuner.xcodeproj/xcshareddata/xcbaselines/8FE56CD925BE05D20038664C.xcbaseline/1C3A5D07-A201-4A8B-B5AE-645392D80492.plist
+++ b/ZenTuner.xcodeproj/xcshareddata/xcbaselines/8FE56CD925BE05D20038664C.xcbaseline/1C3A5D07-A201-4A8B-B5AE-645392D80492.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>ClosestNoteTests</key>
+		<dict>
+			<key>testClosestNote()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00561</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>25</real>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ZenTuner.xcodeproj/xcshareddata/xcbaselines/8FE56CD925BE05D20038664C.xcbaseline/Info.plist
+++ b/ZenTuner.xcodeproj/xcshareddata/xcbaselines/8FE56CD925BE05D20038664C.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>1C3A5D07-A201-4A8B-B5AE-645392D80492</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>6-Core Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2900</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>modelCode</key>
+				<string>MacBookPro15,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>6</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone13,4</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ZenTunerTests/ClosestNoteTests.swift
+++ b/ZenTunerTests/ClosestNoteTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import ZenTuner
+
+class ClosestNoteTests: XCTestCase {
+    func testClosestNote() {
+        let measureOptions = XCTMeasureOptions.default
+        measureOptions.iterationCount = 100
+        measure(options: measureOptions) {
+            for (note, octave, frequency) in kNoteTable {
+                let justFrequency = Frequency(floatLiteral: frequency)
+                let closestNote = ScaleNote.closestNote(to: justFrequency)
+                XCTAssertEqual(closestNote.note, note)
+                XCTAssertEqual(closestNote.octave, octave)
+                XCTAssertFalse(closestNote.distance.isPerceptible)
+
+                let slightlyFlat = ScaleNote.closestNote(to: justFrequency.adding(-12))
+                XCTAssertEqual(slightlyFlat.note, note)
+                XCTAssertEqual(slightlyFlat.octave, octave)
+                XCTAssertTrue(slightlyFlat.distance.cents < 0)
+                XCTAssertTrue(slightlyFlat.distance.isPerceptible)
+
+                let slightlySharp = ScaleNote.closestNote(to: justFrequency.adding(12))
+                XCTAssertEqual(slightlySharp.note, note)
+                XCTAssertEqual(slightlySharp.octave, octave)
+                XCTAssertTrue(slightlySharp.distance.cents > 0)
+                XCTAssertTrue(slightlySharp.distance.isPerceptible)
+            }
+        }
+    }
+}
+
+// From https://pages.mtu.edu/~suits/notefreqs.html
+private let kNoteTable: [(note: ScaleNote, octave: Int, frequency: Double)] = [
+    (.C, 0, 16.3),
+    (.CSharp_DFlat, 0, 17.3),
+    (.D, 0, 18.3),
+    (.DSharp_EFlat, 0, 19.4),
+    (.E, 0, 20.6),
+    (.F, 0, 21.8),
+    (.FSharp_GFlat, 0, 23.1),
+    (.G, 0, 24.5),
+    (.GSharp_AFlat, 0, 25.9),
+    (.A, 0, 27.5),
+    (.ASharp_BFlat, 0, 29.1),
+    (.B, 0, 30.8),
+    (.C, 1, 32.7),
+    (.CSharp_DFlat, 1, 34.6),
+    (.D, 1, 36.7),
+    (.DSharp_EFlat, 1, 38.8),
+    (.E, 1, 41.2),
+    (.F, 1, 43.6),
+    (.FSharp_GFlat, 1, 46.2),
+    (.G, 1, 49.0),
+    (.GSharp_AFlat, 1, 51.9),
+    (.A, 1, 55.0),
+    (.ASharp_BFlat, 1, 58.2),
+    (.B, 1, 61.7),
+    (.C, 2, 65.4),
+    (.CSharp_DFlat, 2, 69.3),
+    (.D, 2, 73.4),
+    (.DSharp_EFlat, 2, 77.7),
+    (.E, 2, 82.4),
+    (.F, 2, 87.3),
+    (.FSharp_GFlat, 2, 92.5),
+    (.G, 2, 98.0),
+    (.GSharp_AFlat, 2, 103.83),
+    (.A, 2, 110.00),
+    (.ASharp_BFlat, 2, 116.54),
+    (.B, 2, 123.47),
+    (.C, 3, 130.81),
+    (.CSharp_DFlat, 3, 138.59),
+    (.D, 3, 146.83),
+    (.DSharp_EFlat, 3, 155.56),
+    (.E, 3, 164.81),
+    (.F, 3, 174.61),
+    (.FSharp_GFlat, 3, 185.00),
+    (.G, 3, 196.00),
+    (.GSharp_AFlat, 3, 207.65),
+    (.A, 3, 220.00),
+    (.ASharp_BFlat, 3, 233.08),
+    (.B, 3, 246.94),
+    (.C, 4, 261.63),
+    (.CSharp_DFlat, 4, 277.18),
+    (.D, 4, 293.66),
+    (.DSharp_EFlat, 4, 311.13),
+    (.E, 4, 329.63),
+    (.F, 4, 349.23),
+    (.FSharp_GFlat, 4, 369.99),
+    (.G, 4, 392.00),
+    (.GSharp_AFlat, 4, 415.30),
+    (.A, 4, 440.00),
+    (.ASharp_BFlat, 4, 466.16),
+    (.B, 4, 493.88),
+    (.C, 5, 523.25),
+    (.CSharp_DFlat, 5, 554.37),
+    (.D, 5, 587.33),
+    (.DSharp_EFlat, 5, 622.25),
+    (.E, 5, 659.25),
+    (.F, 5, 698.46),
+    (.FSharp_GFlat, 5, 739.99),
+    (.G, 5, 783.99),
+    (.GSharp_AFlat, 5, 830.61),
+    (.A, 5, 880.00),
+    (.ASharp_BFlat, 5, 932.33),
+    (.B, 5, 987.77),
+    (.C, 6, 1046.5),
+    (.CSharp_DFlat, 6, 1108.7),
+    (.D, 6, 1174.6),
+    (.DSharp_EFlat, 6, 1244.5),
+    (.E, 6, 1318.5),
+    (.F, 6, 1396.9),
+    (.FSharp_GFlat, 6, 1479.9),
+    (.G, 6, 1567.9),
+    (.GSharp_AFlat, 6, 1661.2),
+    (.A, 6, 1760.0),
+    (.ASharp_BFlat, 6, 1864.6),
+    (.B, 6, 1975.5),
+    (.C, 7, 2093.0),
+    (.CSharp_DFlat, 7, 2217.4),
+    (.D, 7, 2349.3),
+    (.DSharp_EFlat, 7, 2489.0),
+    (.E, 7, 2637.0),
+    (.F, 7, 2793.8),
+    (.FSharp_GFlat, 7, 2959.9),
+    (.G, 7, 3135.9),
+    (.GSharp_AFlat, 7, 3322.4),
+    (.A, 7, 3520.0),
+    (.ASharp_BFlat, 7, 3729.3),
+    (.B, 7, 3951.0),
+    (.C, 8, 4186.0),
+    (.CSharp_DFlat, 8, 4434.9),
+    (.D, 8, 4698.6),
+    (.DSharp_EFlat, 8, 4978.0),
+    (.E, 8, 5274.0),
+    (.F, 8, 5587.6),
+    (.FSharp_GFlat, 8, 5919.9),
+    (.G, 8, 6271.9),
+    (.GSharp_AFlat, 8, 6644.8),
+    (.A, 8, 7040.0),
+    (.ASharp_BFlat, 8, 7458.6),
+    (.B, 8, 7902.1)
+]


### PR DESCRIPTION
Previously could lead to incorrect results for B or C notes at the scale boundary.

Also increase musical distance perception tolerance from 5 cents to 6 after experimentation.