### PR TITLE
Only animate current note marker when distance in cents to note changes

### DIFF
--- a/Shared/Views/CurrentNoteMarker.swift
+++ b/Shared/Views/CurrentNoteMarker.swift
@@ -18,7 +18,7 @@ struct CurrentNoteMarker: View {
             .offset(
                 x: (geometry.size.width / 2) * CGFloat(distance.cents / 50)
             )
-            .animation(.easeInOut)
+            .animation(.easeInOut, value: distance.cents)
         }
     }
 }


### PR DESCRIPTION
This will stop animating when the parent view bounds change, such as when resizing the scene on iPadOS or resizing the window on macOS.