### PR TITLE
Simplify

### DIFF
--- a/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/PitchTracker.mm
+++ b/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/PitchTracker.mm
@@ -10,7 +10,6 @@ struct PitchTracker {
     PitchTracker(size_t sampleRate, int hopSize, int peakCount) {
         zt_create(&sp);
         sp->sr = (int)sampleRate;
-        sp->nchan = 1;
 
         zt_ptrack_create(&ptrack);
         zt_ptrack_init(sp, ptrack, hopSize, peakCount);

--- a/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/base.c
+++ b/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/base.c
@@ -9,15 +9,12 @@ int zt_create(zt_data **spp)
 {
     *spp = (zt_data *) malloc(sizeof(zt_data));
     zt_data *sp = *spp;
-    sprintf(sp->filename, "");
-    sp->nchan = 1;
-    ZTFLOAT *out = malloc(sizeof(ZTFLOAT) * sp->nchan);
+    ZTFLOAT *out = malloc(sizeof(ZTFLOAT));
     *out = 0;
     sp->out = out;
     sp->sr = 44100;
     sp->len = 5 * sp->sr;
     sp->pos = 0;
-    sp->rand = 0;
     return 0;
 }
 

--- a/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/include/CMicrophonePitchDetector.h
+++ b/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/include/CMicrophonePitchDetector.h
@@ -17,19 +17,16 @@ extern "C" {
 #define ZT_OK 1
 #define ZT_NOT_OK 0
 
-typedef struct zt_auxdata {
+typedef struct {
     size_t size;
     void *ptr;
 } zt_auxdata;
 
-typedef struct zt_data {
+typedef struct {
     ZTFLOAT *out;
     int sr;
-    int nchan;
     unsigned long len;
     unsigned long pos;
-    char filename[200];
-    uint32_t rand;
 } zt_data;
 
 int zt_auxdata_alloc(zt_auxdata *aux, size_t size);
@@ -51,7 +48,7 @@ void zt_fft_destroy(zt_fft *fft);
 
 typedef struct {
     ZTFLOAT freq, amp;
-    ZTFLOAT asig,size,peak;
+    ZTFLOAT size;
     zt_auxdata signal, prev, sin, spec1, spec2, peakarray;
     int numpks;
     int cnt;
@@ -61,10 +58,8 @@ typedef struct {
     ZTFLOAT cps;
     ZTFLOAT dbs[20];
     ZTFLOAT amplo;
-    ZTFLOAT amphi;
     ZTFLOAT npartial;
     ZTFLOAT dbfs;
-    ZTFLOAT prevf;
     zt_fft fft;
 } zt_ptrack;
 

--- a/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/ptrack.c
+++ b/Packages/MicrophonePitchDetector/Sources/CMicrophonePitchDetector/ptrack.c
@@ -28,7 +28,6 @@
 #define DBOFFSET -92.3
 #define MINBIN 3
 #define MINAMPS 40
-#define MAXAMPS 50
 
 #define THRSH 10.
 
@@ -160,10 +159,8 @@ int zt_ptrack_init(zt_data *sp, zt_ptrack *p, int ihopsize, int ipeaks)
     p->sr = sp->sr;
     for (i = 0; i < NPREV; i++) p->dbs[i] = -144.0;
     p->amplo = MINAMPS;
-    p->amphi = MAXAMPS;
     p->npartial = 7;
     p->dbfs = 32768.0;
-    p->prevf = p->cps = 100.0;
 
     return ZT_OK;
 }

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
@@ -120,14 +120,6 @@ final class AudioEngine {
         mainMixerNode = mixer
         mixer.silenceOutput()
     }
-
-    private func removeEngineMixer() {
-        guard let mixer = mainMixerNode else { return }
-        avEngine.outputNode.disconnect(input: mixer.avAudioNode)
-        mixer.removeAllInputs()
-        mixer.detach()
-        mainMixerNode = nil
-    }
 }
 
 private extension AVAudioFormat {

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
@@ -35,11 +35,11 @@ public final class MicrophonePitchDetector: ObservableObject {
 
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized: // The user has previously granted access to the microphone.
-            self.setUpAudioSession()
+            self.setUpPitchTracking()
         case .notDetermined: // The user has not yet been asked for microphone access.
             AVCaptureDevice.requestAccess(for: .audio) { granted in
                 if granted {
-                    self.setUpAudioSession()
+                    self.setUpPitchTracking()
                 } else {
                     self.showMicrophoneAccessAlert = true
                     return
@@ -57,21 +57,10 @@ public final class MicrophonePitchDetector: ObservableObject {
         }
     }
 
-    private func setUpAudioSession() {
-#if os(iOS)
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setActive(true)
-        } catch {
-            // TODO: Handle error
-        }
-#endif
-
-        tracker = PitchTap(engine.input) { pitch, amplitude in
-            if amplitude[0] > 0.1 {
-                DispatchQueue.main.async {
-                    self.pitch = pitch[0]
-                }
+    private func setUpPitchTracking() {
+        tracker = PitchTap(engine.input) { pitch in
+            DispatchQueue.main.async {
+                self.pitch = pitch
             }
         }
 

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTap.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTap.swift
@@ -4,70 +4,23 @@ import AVFoundation
 import CMicrophonePitchDetector
 
 /// Tap to do pitch tracking on any node.
-/// start() will add the tap, and stop() will remove it.
 final class PitchTap {
     // MARK: - Properties
 
-    /// Size of buffer to analyze
     private var bufferSize: UInt32 { 4_096 }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    private var isStarted = false
-
-    /// The bus to install the tap onto
-    private var bus: Int = 0 {
-        didSet {
-            if isStarted {
-                stop()
-                start()
-            }
-        }
-    }
-
-    /// Input node to analyze
     private let input: Node
+    private var tracker: PitchTrackerRef?
+    private let handler: (Float) -> Void
 
-    private var pitch: [Float] = [0, 0]
-    private var amp: [Float] = [0, 0]
-    private var trackers: [PitchTrackerRef] = []
-    private var unfairLock = os_unfair_lock_s()
-
-    /// Callback type
-    typealias Handler = ([Float], [Float]) -> Void
-    private var handler: Handler = { _, _ in }
-
-    // MARK: - Starting & Stopping
+    // MARK: - Starting
 
     /// Enable the tap on input
     func start() {
-        lock()
-        defer {
-            unlock()
-        }
-        guard !isStarted else { return }
-        isStarted = true
-
-        // a node can only have one tap at a time installed on it
-        // make sure any previous tap is removed.
-        // We're making the assumption that the previous tap (if any)
-        // was installed on the same bus as our bus var.
-        removeTap()
-
+        input.avAudioNode.removeTap(onBus: 0)
         input.avAudioNode
-            .installTap(onBus: bus, bufferSize: bufferSize, format: nil) { [weak self] buffer, _ in
-                self?.handleTapBlock(buffer: buffer)
+            .installTap(onBus: 0, bufferSize: bufferSize, format: nil) { [weak self] buffer, _ in
+                self?.analyzePitch(buffer: buffer)
             }
-    }
-
-    /// Stop detecting pitch
-    func stop() {
-        lock()
-        removeTap()
-        isStarted = false
-        unlock()
-        for idx in 0 ..< pitch.count {
-            pitch[idx] = 0.0
-        }
     }
 
     // MARK: - Lifecycle
@@ -76,76 +29,39 @@ final class PitchTap {
     ///
     /// - Parameters:
     ///   - input: Node to analyze
-    ///   - handler: Callback to call on each analysis pass
-    init(_ input: Node, handler: @escaping Handler) {
+    ///   - handler: Callback to call when a pitch is detected
+    init(_ input: Node, handler: @escaping (Float) -> Void) {
         self.input = input
         self.handler = handler
     }
 
     deinit {
-        for tracker in trackers {
+        if let tracker = self.tracker {
             ztPitchTrackerDestroy(tracker)
         }
     }
 
     // MARK: - Private
 
-    /// Handle new buffer data
-    /// - Parameters:
-    ///   - buffer: Buffer to analyze
-    ///   - time: Unused in this case
-    private func handleTapBlock(buffer: AVAudioPCMBuffer) {
-        // Call on the main thread so the client doesn't have to worry
-        // about thread safety.
-        buffer.frameLength = bufferSize
-        DispatchQueue.main.async {
-            // Create trackers as needed.
-            self.lock()
-            guard self.isStarted == true else {
-                self.unlock()
-                return
-            }
-            self.analyzePitch(buffer: buffer)
-            self.unlock()
-        }
-    }
-
-    private func removeTap() {
-        input.avAudioNode.removeTap(onBus: bus)
-    }
-
-    private func lock() {
-        os_unfair_lock_lock(&unfairLock)
-    }
-
-    private func unlock() {
-        os_unfair_lock_unlock(&unfairLock)
-    }
-
     private func analyzePitch(buffer: AVAudioPCMBuffer) {
+        buffer.frameLength = bufferSize
         guard let floatData = buffer.floatChannelData else { return }
-        let channelCount = Int(buffer.format.channelCount)
-        let length = UInt(buffer.frameLength)
-        while self.trackers.count < channelCount {
-            self.trackers.append(ztPitchTrackerCreate(UInt32(buffer.format.sampleRate), 4_096, 20))
+
+        let tracker: PitchTrackerRef
+        if let existingTracker = self.tracker {
+            tracker = existingTracker
+        } else {
+            tracker = ztPitchTrackerCreate(UInt32(buffer.format.sampleRate), Int32(bufferSize), 20)
+            self.tracker = tracker
         }
 
-        while self.amp.count < channelCount {
-            self.amp.append(0)
-            self.pitch.append(0)
+        ztPitchTrackerAnalyze(tracker, floatData[0], bufferSize)
+        var amp: Float = 0
+        var pitch: Float = 0
+        ztPitchTrackerGetResults(tracker, &amp, &pitch)
+
+        if amp > 0.1 {
+            self.handler(pitch)
         }
-
-        for channel in 0 ..< channelCount {
-            let data = floatData[channel]
-
-            ztPitchTrackerAnalyze(self.trackers[channel], data, UInt32(length))
-
-            var amp: Float = 0
-            var pitch: Float = 0
-            ztPitchTrackerGetResults(self.trackers[channel], &amp, &pitch)
-            self.amp[channel] = amp
-            self.pitch[channel] = pitch
-        }
-        self.handler(self.pitch, self.amp)
     }
 }


### PR DESCRIPTION
- Bus doesn't change.
- We discard all pitch/amplitude data other than the first channel, so
  might as well avoid computing it and remove it from the data flow.
- Also remove amplitude from the PitchTap callback since we can discard
  quiet values internally.
- Perform the analysis on the AVAudio callback thread, since we already
  dispatch back to main in `MicrophonePitchDetector`.
- Remove the ability to stop the pitch tap. We never stop it, we only
  stop the audio engine.
- Remove the isStarted book keeping since we only ever start the pitch
  tap once and never stop it.
- Remove the need for locking since we're not mutating shared state
  concurrently any more.
- It wasn't necessary to mark the audio session as active.
- We never removed the engine mixer, so we don't need that function.
- Some fields in the `zt_data` and `zt_ptrack` C structs were unused.