### PR TITLE
Disable idle timer on iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/ZenTuner/ZenTunerApp.swift
+++ b/ZenTuner/ZenTunerApp.swift
@@ -5,6 +5,11 @@ struct ZenTunerApp: App {
     var body: some Scene {
         WindowGroup {
             TunerScreen()
+                .onAppear {
+                    #if os(iOS)
+                        UIApplication.shared.isIdleTimerDisabled = true
+                    #endif
+                }
         }
     }
 }


### PR DESCRIPTION
@jpsim thanks for this app and making it open-source! I use it all the time, but have one minor annoyance where I'll have it on a table while tuning my guitar and the display will dim and I can't see the notes. I guess I'm a slow tuner. This sets the `UIApplication.isIdleTimerDisabled` setting to `true` so the display will stay completely on even without user interaction. I wasn't sure the best place to set that in a SwiftUI app, in UIKit I'd set it in the AppDelegate or SceneDelegate.

I also added a simple `.gitignore` since there wasn't one and it was picking up all the user data and `.swiftpm` files that shouldn't be committed.