### PR TITLE
Fix Swift 5.6 warning

### DIFF
--- a/ZenTuner/Models/ScaleNote.swift
+++ b/ZenTuner/Models/ScaleNote.swift
@@ -1,8 +1,11 @@
 import Darwin.C.math
+import SwiftUI
 
 /// A note in a twelve-tone equal temperament scale. https://en.wikipedia.org/wiki/Equal_temperament
-enum ScaleNote: Int, CaseIterable {
+enum ScaleNote: Int, CaseIterable, Identifiable {
     case C, CSharp_DFlat, D, DSharp_EFlat, E, F, FSharp_GFlat, G, GSharp_AFlat, A, ASharp_BFlat, B
+
+    var id: Int { rawValue }
 
     /// A note match given an input frequency.
     struct Match: Hashable {

--- a/ZenTuner/Views/TranspositionMenu.swift
+++ b/ZenTuner/Views/TranspositionMenu.swift
@@ -1,25 +1,25 @@
 import SwiftUI
 
 struct TranspositionMenu: View {
-    private let transpositions = ScaleNote.allCases.map(\.transpositionName)
+    private let transpositions = ScaleNote.allCases
     @Binding var selectedTransposition: Int
 
     var body: some View {
         Menu(
             content: {
-                ForEach(0..<transpositions.count) { index in
+                ForEach(transpositions) { transposition in
                     Button(
                         action: {
-                            selectedTransposition = index
+                            selectedTransposition = transposition.rawValue
                         },
                         label: {
-                            Text(transpositions[index])
+                            Text(transposition.transpositionName)
                         }
                     )
                 }
             },
             label: {
-                Text(transpositions[selectedTransposition])
+                Text(transpositions[selectedTransposition].transpositionName)
                     // Increase tap area, some of the transpositions are just a single
                     // letter so the tap area can otherwise be quite small.
                     .frame(minWidth: 100, alignment: .leading)


### PR DESCRIPTION
> Non-constant range: argument must be an integer literal