### PR TITLE
Fix launching with Siri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
 * iOS 15 and macOS 12 are now required.
+* Fixed an issue where the tuner would not process audio when launched
+  in some conditions, such as when using Siri to launch the app.
 
 ## 0.2.2
 

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
@@ -77,14 +77,6 @@ final class AudioEngine {
 #endif
     }
 
-    /// Stop the engine
-    func stop() throws {
-        avEngine.stop()
-#if os(iOS)
-        try session.setActive(false)
-#endif
-    }
-
     // MARK: - Private
 
     private func createSilentOutput() {

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
@@ -20,9 +20,9 @@ public final class MicrophonePitchDetector: ObservableObject {
         var intervalMS: UInt64 = 30
 
         while !didReceiveAudio {
-            try! await Task.sleep(nanoseconds: intervalMS * NSEC_PER_MSEC)
+            try? await Task.sleep(nanoseconds: intervalMS * NSEC_PER_MSEC)
             await checkMicrophoneAuthorizationStatus()
-            try! await Task.sleep(nanoseconds: intervalMS * NSEC_PER_MSEC)
+            try? await Task.sleep(nanoseconds: intervalMS * NSEC_PER_MSEC)
             start()
             intervalMS = min(intervalMS * 2, 180)
         }

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTap.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTap.swift
@@ -10,6 +10,7 @@ final class PitchTap {
     private let input: Node
     private var tracker: PitchTracker?
     private let handler: (Float) -> Void
+    private let didReceiveAudio: () -> Void
 
     // MARK: - Starting
 
@@ -29,9 +30,11 @@ final class PitchTap {
     /// - Parameters:
     ///   - input: Node to analyze
     ///   - handler: Callback to call when a pitch is detected
-    init(_ input: Node, handler: @escaping (Float) -> Void) {
+    ///   - didReceiveAudio: Callback to call when any audio is detected
+    init(_ input: Node, handler: @escaping (Float) -> Void, didReceiveAudio: @escaping () -> Void) {
         self.input = input
         self.handler = handler
+        self.didReceiveAudio = didReceiveAudio
     }
 
     // MARK: - Private
@@ -39,6 +42,8 @@ final class PitchTap {
     private func analyzePitch(buffer: AVAudioPCMBuffer) {
         buffer.frameLength = bufferSize
         guard let floatData = buffer.floatChannelData else { return }
+
+        didReceiveAudio()
 
         let tracker: PitchTracker
         if let existingTracker = self.tracker {

--- a/ZenTuner/TunerScreen.swift
+++ b/ZenTuner/TunerScreen.swift
@@ -2,7 +2,6 @@ import MicrophonePitchDetector
 import SwiftUI
 
 struct TunerScreen: View {
-    @Environment(\.scenePhase) private var scenePhase
     @ObservedObject private var pitchDetector = MicrophonePitchDetector()
     @AppStorage("modifierPreference") private var modifierPreference = ModifierPreference.preferSharps
     @AppStorage("selectedTransposition") private var selectedTransposition = 0
@@ -13,15 +12,8 @@ struct TunerScreen: View {
             modifierPreference: modifierPreference,
             selectedTransposition: selectedTransposition
         )
-        .onChange(of: scenePhase) { phase in
-            switch phase {
-            case .active:
-                pitchDetector.start()
-            case .inactive, .background:
-                pitchDetector.stop()
-            @unknown default:
-                pitchDetector.stop()
-            }
+        .task {
+            await pitchDetector.activate()
         }
         .alert(isPresented: $pitchDetector.showMicrophoneAccessAlert) {
             MicrophoneAccessAlert()


### PR DESCRIPTION
The app sometimes would launch and just not process any audio input.

I found I was able to consistently reproduce this when launching the app via Siri: "Hey Siri, launch Zen Tuner".

To fix this, I periodically check for the microphone access and then start the audio capture. I use an exponential backoff strategy so this happens as quickly as possible without over-taxing the system.

As part of this change, Zen Tuner no longer stops the audio capture explicitly when backgrounding the app. The OS takes care of doing this automatically in my testing (iOS 16.2).