### PR TITLE
Dim UI when audio session is starting up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * iOS 15 and macOS 12 are now required.
 * Fixed an issue where the tuner would not process audio when launched
   in some conditions, such as when using Siri to launch the app.
+* The UI now dims when audio session is starting up to make it easier to
+  know when when the tuner starts capturing audio.
 
 ## 0.2.2
 

--- a/ZenTuner/TunerScreen.swift
+++ b/ZenTuner/TunerScreen.swift
@@ -12,6 +12,8 @@ struct TunerScreen: View {
             modifierPreference: modifierPreference,
             selectedTransposition: selectedTransposition
         )
+        .opacity(pitchDetector.didReceiveAudio ? 1 : 0.5)
+        .animation(.easeInOut, value: pitchDetector.didReceiveAudio)
         .task {
             await pitchDetector.activate()
         }


### PR DESCRIPTION
This makes it easier to tell when the tuner isn't yet capturing audio