### PR TITLE
Refactor PitchTracker to make it easier to use directly

### DIFF
--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTracker.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTracker.swift
@@ -1,10 +1,13 @@
+import AVFoundation
 import CMicrophonePitchDetector
 
 final class PitchTracker {
     private var data: UnsafeMutablePointer<zt_data>?
     private var ptrack: UnsafeMutablePointer<zt_ptrack>?
 
-    init(sampleRate: Int32, hopSize: Int32, peakCount: Int32) {
+    static var defaultBufferSize: UInt32 { 4_096 }
+
+    init(sampleRate: Int32, hopSize: Int32 = Int32(PitchTracker.defaultBufferSize), peakCount: Int32 = 20) {
         withUnsafeMutablePointer(to: &data, zt_create)
         data!.pointee.sr = sampleRate
         withUnsafeMutablePointer(to: &ptrack, zt_ptrack_create)
@@ -16,15 +19,18 @@ final class PitchTracker {
         withUnsafeMutablePointer(to: &data, zt_destroy)
     }
 
-    func getPitch(frames: [UnsafeMutablePointer<Float>]) -> Float? {
+    func getPitch(from buffer: AVAudioPCMBuffer, amplitudeThreshold: Float = 0.1) -> Float? {
+        guard let floatData = buffer.floatChannelData else { return nil }
+
         var pitch: Float = 0
         var amplitude: Float = 0
 
+        let frames = (0..<Int(buffer.frameLength)).map { floatData[0].advanced(by: $0) }
         for frame in frames {
             zt_ptrack_compute(data, ptrack, frame, &pitch, &amplitude)
         }
 
-        if amplitude > 0.1 {
+        if amplitude > amplitudeThreshold, pitch > 0 {
             return pitch
         } else {
             return nil


### PR DESCRIPTION
This will be useful for upcoming pitch detection unit tests.

* Add `PitchTracker.defaultBufferSize`
* Discard `0` pitch values
* Add `amplitudeThreshold` parameter to control what the threshold should be
* Process `AVAudioPCMBuffer` from `PitchTracker` instead of raw `UnsafeMutablePointer<Float>` frames