### PR TITLE
Use `Double` instead of `Float` for MicrophonePitchDetector APIs

### DIFF
--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
@@ -9,7 +9,7 @@ public final class MicrophonePitchDetector: ObservableObject {
     private var hasMicrophoneAccess = false
     private var tracker: PitchTap!
 
-    @Published public var pitch: Float = 440
+    @Published public var pitch: Double = 440
     @Published public var didReceiveAudio = false
     @Published public var showMicrophoneAccessAlert = false
 

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTap.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTap.swift
@@ -9,7 +9,7 @@ final class PitchTap {
     private var bufferSize: UInt32 { PitchTracker.defaultBufferSize }
     private let input: Node
     private var tracker: PitchTracker?
-    private let handler: (Float) -> Void
+    private let handler: (Double) -> Void
     private let didReceiveAudio: () -> Void
 
     // MARK: - Starting
@@ -31,7 +31,7 @@ final class PitchTap {
     ///   - input: Node to analyze
     ///   - handler: Callback to call when a pitch is detected
     ///   - didReceiveAudio: Callback to call when any audio is detected
-    init(_ input: Node, handler: @escaping (Float) -> Void, didReceiveAudio: @escaping () -> Void) {
+    init(_ input: Node, handler: @escaping (Double) -> Void, didReceiveAudio: @escaping () -> Void) {
         self.input = input
         self.handler = handler
         self.didReceiveAudio = didReceiveAudio

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTracker.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/PitchTracker.swift
@@ -19,16 +19,19 @@ public final class PitchTracker {
         withUnsafeMutablePointer(to: &data, zt_destroy)
     }
 
-    public func getPitch(from buffer: AVAudioPCMBuffer, amplitudeThreshold: Float = 0.1) -> Float? {
+    public func getPitch(from buffer: AVAudioPCMBuffer, amplitudeThreshold: Double = 0.1) -> Double? {
         guard let floatData = buffer.floatChannelData else { return nil }
 
-        var pitch: Float = 0
-        var amplitude: Float = 0
+        var fpitch: Float = 0
+        var famplitude: Float = 0
 
         let frames = (0..<Int(buffer.frameLength)).map { floatData[0].advanced(by: $0) }
         for frame in frames {
-            zt_ptrack_compute(data, ptrack, frame, &pitch, &amplitude)
+            zt_ptrack_compute(data, ptrack, frame, &fpitch, &famplitude)
         }
+
+        let pitch = Double(fpitch)
+        let amplitude = Double(famplitude)
 
         if amplitude > amplitudeThreshold, pitch > 0 {
             return pitch

--- a/ZenTuner/Models/TunerData.swift
+++ b/ZenTuner/Models/TunerData.swift
@@ -4,8 +4,8 @@ struct TunerData {
 }
 
 extension TunerData {
-    init(pitch: Float = 440) {
-        self.pitch = Frequency(floatLiteral: Double(pitch))
+    init(pitch: Double = 440) {
+        self.pitch = Frequency(floatLiteral: pitch)
         self.closestNote = ScaleNote.closestNote(to: self.pitch)
     }
 }


### PR DESCRIPTION
`pitchbench` performance isn't affected in my tests.