### PR TITLE
Configure the audio session before starting the engine

### DIFF
--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
@@ -36,9 +36,6 @@ extension AVAudioMixerNode {
 final class AudioEngine {
     /// Internal AVAudioEngine
     private let avEngine = AVAudioEngine()
-#if os(iOS)
-    private let session = AVAudioSession.sharedInstance()
-#endif
 
     /// Main mixer at the end of the signal chain
     private var mainMixerNode: Mixer?

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
@@ -71,11 +71,20 @@ final class AudioEngine {
     /// Start the engine
     func start() throws {
         try avEngine.start()
-#if os(iOS)
-        try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .mixWithOthers])
-        try session.setActive(true)
-#endif
     }
+
+#if !os(macOS)
+    /// Configures the audio session
+    func configureSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        let bufferDuration = 7 / AVAudioFormat.stereo.sampleRate
+#if !os(watchOS)
+        try session.setPreferredIOBufferDuration(bufferDuration)
+        try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .mixWithOthers])
+#endif
+        try session.setActive(true)
+    }
+#endif
 
     // MARK: - Private
 


### PR DESCRIPTION
This appears to more reliably receive audio quickly in iOS 16 and fixes
the ability to receive audio completely in iOS 17.

Also more consistently configure the audio session across all platforms
that support it. That's all platforms other than macOS, including
visionOS.
